### PR TITLE
Update expiring cache

### DIFF
--- a/src/Cosmos/Prelude.fs
+++ b/src/Cosmos/Prelude.fs
@@ -7,7 +7,6 @@ module Result =
         | MessageCollisionError
         | NotFoundError
         | AlreadyExistsError
-        | ExpiredError
         | StoreError
         | AggregateError of Error list
 

--- a/test/Cosmos.Tests/StoreTests.fs
+++ b/test/Cosmos.Tests/StoreTests.fs
@@ -6,67 +6,110 @@ open Cosmos.Types
 open Cosmos.Store
 
 module ExpiringCacheTests =
+
     [<Fact>]
-    let ``Can store and retrieve item from expiring cache`` () =
+    let ``Can create and read item from expiring cache`` () =
         let cache = ExpiringCache()
         let ttl = TimeToLive 1<hr>
-        cache.Add ttl "1" "test" |> ignore
+        cache.Create ttl "1" "test" |> ignore
 
-        let item = cache.Get "1"
+        let item = cache.Read "1"
 
         let expected = Ok "test"
 
         Assert.Equal(expected, item)
 
     [<Fact>]
-    let ``Cannot retrieve expired item from expiring cache`` () =
+    let ``Cannot read expired item from expiring cache`` () =
         let cache = ExpiringCache()
         let ttl = TimeToLive -1<hr>
-        cache.Add ttl "1" "test" |> ignore
+        cache.Create ttl "1" "test" |> ignore
 
-        let item = cache.Get "1"
+        let item = cache.Read "1"
 
-        let expected = Error ExpiredError
+        let expected = Error NotFoundError
 
         Assert.Equal(expected, item)
 
     [<Fact>]
-    let ``Cannot add to expiring cache when non-expired item exists`` () =
+    let ``Cannot create to expiring cache when non-expired item exists`` () =
         let cache = ExpiringCache()
         let ttl = TimeToLive 1<hr>
-        cache.Add ttl "1" "test" |> ignore
+        cache.Create ttl "1" "test" |> ignore
 
-        let item = cache.Add ttl "1" "this already exists"
+        let item = cache.Create ttl "1" "this already exists"
 
         let expected = Error AlreadyExistsError
 
         Assert.Equal(expected, item)
 
     [<Fact>]
-    let ``Can add to expiring cache when expired item exists`` () =
+    let ``Can create to expiring cache when expired item exists`` () =
         let cache = ExpiringCache()
         let ttl = TimeToLive -1<hr>
-        cache.Add ttl "1" "test" |> ignore
+        cache.Create ttl "1" "test" |> ignore
 
         let newTtl = TimeToLive 1<hr>
-        let item = cache.Add newTtl "1" "new item"
+        let item = cache.Create newTtl "1" "new item"
 
         let expected = Ok "new item"
 
         Assert.Equal(expected, item)
 
     [<Fact>]
-    let ``Can get non-expired items from expiring cache`` () =
+    let ``Can read non-expired items from expiring cache`` () =
         let cache = ExpiringCache()
         let ttl = TimeToLive 1<hr>
-        cache.Add ttl "1" "test1" |> ignore
-        cache.Add ttl "2" "test2" |> ignore
+        cache.Create ttl "1" "test1" |> ignore
+        cache.Create ttl "2" "test2" |> ignore
         
         let oldTtl = TimeToLive -1<hr>
-        cache.Add oldTtl "3" "expired item" |> ignore
+        cache.Create oldTtl "3" "expired item" |> ignore
 
-        let items = cache.Values ()
+        let items =
+            cache.Values ()
+            |> Seq.sort
 
-        let expected = [ "test1"; "test2" ]
+        let expected =
+            [ "test1"; "test2" ]
+            |> List.sort
 
         Assert.Equal(expected, items)
+
+    [<Fact>]
+    let ``Can update item in expiring cache`` () =
+        let cache = ExpiringCache()
+        let ttl = TimeToLive 1<hr>
+        cache.Create ttl "1" "test" |> ignore
+
+        let newItem = "updated test"
+        cache.Update "1" newItem |> ignore
+        
+        let item = cache.Read "1"
+        let expected = Ok newItem
+
+        Assert.Equal(expected, item)
+
+    [<Fact>]
+    let ``Cannot update a non-existing item in expiring cache`` () =
+        let cache = ExpiringCache()
+
+        let newItem = "attempted updated test"
+        let item = cache.Update "1" newItem
+
+        let expected = Error NotFoundError
+
+        Assert.Equal(expected, item)
+
+    [<Fact>]
+    let ``Cannot update an expired item in expiring cache`` () =
+        let cache = ExpiringCache()
+        let ttl = TimeToLive -1<hr>
+        cache.Create ttl "1" "test" |> ignore
+
+        let newItem = "updated test"
+        let item = cache.Update "1" newItem
+
+        let expected = Error NotFoundError
+
+        Assert.Equal(expected, item)


### PR DESCRIPTION
This PR includes a refactor to use a concurrent dictionary, allowing for thread safety. 

Also, an update method was added to the cache, as well as naming the cache methods to align with CRUD to prevent confusion. 

Resolves #8 